### PR TITLE
magento 2.3 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,12 +14,11 @@
         "g suite"
     ],
     "require": {
-        "php": "~5.6.0|7.0.2|7.0.4|~7.0.6|~7.1.0",
-        "magento/module-backend": "100.0.*|100.1.*|100.2.*",
-        "magento/framework": "100.0.*|100.1.*|101.0.*"
+        "php": "~5.6.0|7.0.2|7.0.4|~7.0.6|~7.1.0|~7.2.0",
+        "magento/module-backend": "100.0.*|100.1.*|100.2.*|101.0.*",
+        "magento/framework": "100.0.*|100.1.*|101.0.*|102.0.*"
     },
     "type": "magento2-module",
-    "version": "2.5.5",
     "license": [
         "proprietary"
     ],


### PR DESCRIPTION
- changes the version requirements to support Magento 2.3
- removed the version from composer.json, because it's unnecessary: composer can infer this from git tags. so you just need to tag a new release.