### PR TITLE
Magento 2.3.x fix typo in Class "Fatal error"

### DIFF
--- a/Plugin/Mail/TransportPlugin.php
+++ b/Plugin/Mail/TransportPlugin.php
@@ -15,7 +15,7 @@ use Magento\Framework\Mail\TransportInterface;
 use MagePal\GmailSmtpApp\Helper\Data;
 use MagePal\GmailSmtpApp\Model\Store;
 use MagePal\GmailSmtpApp\Model\ZendMailOne\Smtp as ZendMailOneSmtp;
-use MagePal\GmailSmtpApp\Model\ZendMailTWO\Smtp as ZendMailTwoSmtp;
+use MagePal\GmailSmtpApp\Model\ZendMailTwo\Smtp as ZendMailTwoSmtp;
 use Zend_mail;
 use Zend_Mail_Exception;
 use Zend_Mail_Transport_Smtp;


### PR DESCRIPTION
It have me a 10 minute headache because I was like the class is there, but it turns out you had a typo in the plugin.

