### PR TITLE
Fix send email from office365

### DIFF
--- a/Block/Adminhtml/EmailTest.php
+++ b/Block/Adminhtml/EmailTest.php
@@ -328,7 +328,7 @@ class EmailTest extends Template
             $this->_email
                 ->setTemplateVars(['hash' => $this->hash])
                 ->send(
-                    ['email' => $this->fromAddress, 'name' => $this->fromAddress],
+                    ['email' => $this->fromAddress, 'name' => 'Test from MagePal SMTP'],
                     ['email' => $this->toAddress, 'name' => $this->toAddress]
                 );
         } catch (Exception $e) {


### PR DESCRIPTION
When email is used instead of from name, office 365 blocks the sending and returns 5.2.0 exeption https://docs.microsoft.com/en-us/exchange/troubleshoot/email-messages/mapiexceptionnotfound-ndr