### PR TITLE
Solve Invalid Header Value issue 

### DIFF
--- a/Model/TwoDotThree/Smtp.php
+++ b/Model/TwoDotThree/Smtp.php
@@ -80,6 +80,7 @@ class Smtp
 
         $encoding = $message->getEncoding();
         $message = Message::fromString($message->getRawMessage());
+        $message->getHeaders()->get('to')->setEncoding('utf-8');
         $message->getHeaders()->setEncoding('utf-8');
         $message->setEncoding($encoding);
 

--- a/Model/TwoDotThree/Smtp.php
+++ b/Model/TwoDotThree/Smtp.php
@@ -80,6 +80,7 @@ class Smtp
 
         $encoding = $message->getEncoding();
         $message = Message::fromString($message->getRawMessage());
+        $message->getHeaders()->setEncoding('utf-8');
         $message->setEncoding($encoding);
 
         //Set reply-to path

--- a/Model/TwoDotThree/Smtp.php
+++ b/Model/TwoDotThree/Smtp.php
@@ -78,7 +78,9 @@ class Smtp
         $dataHelper = $this->dataHelper;
         $dataHelper->setStoreId($this->storeModel->getStoreId());
 
+        $encoding = $message->getEncoding();
         $message = Message::fromString($message->getRawMessage());
+        $message->setEncoding($encoding);
 
         //Set reply-to path
         switch ($dataHelper->getConfigSetReturnPath()) {

--- a/Model/ZendMailTwo/Smtp.php
+++ b/Model/ZendMailTwo/Smtp.php
@@ -173,6 +173,7 @@ class Smtp
         try {
             $transport = new SmtpTransport();
             $transport->setOptions($options);
+            $message->getHeaders()->get('to')->setEncoding('utf-8');
             $transport->send($message);
         } catch (Exception $e) {
             throw new MailException(


### PR DESCRIPTION
See https://github.com/magepal/magento2-gmail-smtp-app/issues/152

The changes in this PR solved the e-mail sending issues with Magento 2.3.3 for us.
We are not receiving "Invalid header value" any more when sending e-mails where the customer name contains umlauts (like "ö" etc.).
