### PR TITLE
Small code style fixes

### DIFF
--- a/Model/ZendMailOne/Smtp.php
+++ b/Model/ZendMailOne/Smtp.php
@@ -13,13 +13,13 @@ use Magento\Framework\Mail\MessageInterface;
 use Magento\Framework\Phrase;
 use MagePal\GmailSmtpApp\Helper\Data;
 use MagePal\GmailSmtpApp\Model\Store;
-use Zend_mail;
+use Zend_Mail;
 use Zend_Mail_Exception;
 use Zend_Mail_Transport_Smtp;
 
 /**
  * Class Smtp
- * For Magento < 2.2.8
+ * For Magento <= 2.2.7
  */
 
 class Smtp extends Zend_Mail_Transport_Smtp

--- a/Model/ZendMailTwo/Smtp.php
+++ b/Model/ZendMailTwo/Smtp.php
@@ -21,7 +21,7 @@ use Magento\Framework\Mail\EmailMessageInterface;
 
 /**
  * Class Smtp
- * For Magento > 2.2.7
+ * For Magento >= 2.2.8
  */
 class Smtp
 {

--- a/Plugin/Mail/TransportPlugin.php
+++ b/Plugin/Mail/TransportPlugin.php
@@ -17,10 +17,9 @@ use MagePal\GmailSmtpApp\Model\ZendMailOne\Smtp as ZendMailOneSmtp;
 use MagePal\GmailSmtpApp\Model\ZendMailTwo\Smtp as ZendMailTwoSmtp;
 use Zend_Mail;
 use Zend_Mail_Exception;
-use Zend_Mail_Transport_Smtp;
 use \Magento\Framework\Mail\EmailMessageInterface;
 
-class TransportPlugin extends Zend_Mail_Transport_Smtp
+class TransportPlugin
 {
     /**
      * @var Data

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -8,13 +8,13 @@
 -->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:ObjectManager/etc/config.xsd">
 	<!-- For Magento < 2.2 -->
-	<preference for="\Magento\Framework\Mail\Transport" type="MagePal\GmailSmtpApp\Model\Transport"/>
+	<preference for="Magento\Framework\Mail\Transport" type="MagePal\GmailSmtpApp\Model\Transport"/>
 	<type name="MagePal\GmailSmtpApp\Model\Transport">
 		<plugin sortOrder="100" name="magePalGmailSmtpAppTransport" type="MagePal\GmailSmtpApp\Plugin\Mail\TransportPlugin"/>
 	</type>
 
 	<!-- For Magento Eq 2.2 -->
-	<type name="\Magento\Framework\Mail\TransportInterface">
+	<type name="Magento\Framework\Mail\TransportInterface">
 		<plugin sortOrder="100" name="magePalGmailSmtpAppTransportInterface" type="MagePal\GmailSmtpApp\Plugin\Mail\TransportPlugin"/>
 	</type>
 


### PR DESCRIPTION
1. Missed fix for Zend classes from PR #161.
2. Removed extending TransportPlugin by Zend_Mail_Transport_Smtp - it doesn't use  something from that class - all was implemented in Smtp classes.
3. Fixed comments in Smtp classes according versions.
4. Removed extra slashes in di.xml.