### PR TITLE
Don't activate by default

### DIFF
--- a/etc/config.xml
+++ b/etc/config.xml
@@ -10,7 +10,7 @@
     <default>
         <system>
             <gmailsmtpapp>
-                <active>1</active>
+                <active>0</active>
                 <name>localhost</name>
                 <ssl>ssl</ssl>
                 <auth>LOGIN</auth>


### PR DESCRIPTION
Don't activate by default. Most modules that alter behaviour need to be enabled manually to prevent issues when putting this live.