### PR TITLE
fix: allow magento 2.4.8-p2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "php": "~8.2.0||~8.3.0||~8.4.0",
         "magento/module-backend": "102.0.*",
         "magento/framework": "103.0.*",
-        "magento/module-email": "101.1.8 || 101.1.8-p1",
+        "magento/module-email": "101.1.8*",
         "magepal/magento2-core":">1.1.0"
     },
     "type": "magento2-module",


### PR DESCRIPTION
Loosen contraint to allow any sub patch version of module-email 101.1.8

Fixes issue where p2 cannot be installed:

```
  Problem 1
    - Root composer.json requires magento/product-community-edition 2.4.8-p2 -> satisfiable by magento/product-community-edition[2.4.8-p2].
    - magento/product-community-edition 2.4.8-p2 requires magento/module-email 101.1.8-p2 -> found magento/module-email[101.1.8-p2] but these were not loaded, likely because it conflicts with another require.
```